### PR TITLE
Convert Throwables to Exceptions

### DIFF
--- a/Plugin/HttpApp.php
+++ b/Plugin/HttpApp.php
@@ -12,9 +12,12 @@ declare(strict_types=1);
 
 namespace Yireo\Whoops\Plugin;
 
+use Closure;
+use Exception;
 use Throwable;
 use Magento\Framework\App\Bootstrap;
 use Magento\Framework\App\Http;
+use Magento\Framework\App\ResponseInterface;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run as WhoopsRunner;
 use Yireo\Whoops\Config\Config;
@@ -86,5 +89,29 @@ class HttpApp
         }
 
         return false;
+    }
+
+    /**
+     * @param Http $subject
+     * @param Closure $proceed
+     * @return ResponseInterface
+     * @throws Exception
+     */
+    public function aroundLaunch(Http $subject, Closure $proceed): ResponseInterface
+    {
+        try {
+            return $proceed();
+        } catch (Throwable $e) {
+            if ($e instanceof Exception) {
+                throw $e;
+            }
+
+            /**
+             * Convert the Throwable to an exception for it to be caught by the main catch(\Exception) block.
+             *
+             * @see \Magento\Framework\App\Bootstrap::run
+             */
+            throw new Exception($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }


### PR DESCRIPTION
Currently, if the running code throws an error that is not an instance of Exception, Magento's error handling won't pick it up as it's only catching \Exception. By creating a plugin around the `\Magento\Framework\App\Http::launch` method, any Throwable can be converted to an Exception instance. 

While the downside is that the first item in the stacktrace will be the plugin, the upside is that you no longer only see "500 Internal Server Error" in the browser, but the actual error rendered in Whoops:

![image](https://user-images.githubusercontent.com/6512901/78693312-5e279c00-78fb-11ea-80fe-6d354d617f1f.png)

